### PR TITLE
Traduz status da reserva para portugues

### DIFF
--- a/models/reserve.js
+++ b/models/reserve.js
@@ -2,10 +2,9 @@ const mongoose = require("mongoose");
 const Schema = mongoose.Schema;
 
 const status = Object.freeze({
-  Pendding: 'pendding',
-  Accept: 'accept',
-  Canceled: 'canceled',
-  Finalized: 'finalized'
+  Pendente: 'pendente',
+  Aceita: 'aceita',
+  Cancelada: 'cancelada'
 })
 
 const ReserveSchema = new Schema({
@@ -27,7 +26,7 @@ const ReserveSchema = new Schema({
     type: Schema.Types.String,
     required: true,
     enum: Object.values(status),
-    default: status.Pendding
+    default: status.Pendente
   },
   date: [{
     type: Schema.Types.ObjectId,

--- a/routes/reserve.js
+++ b/routes/reserve.js
@@ -92,7 +92,7 @@ router.put("/cancel/:_id", verifyToken, async (req, res) => {
             })
         }
 
-        reserve.status = "canceled";
+        reserve.status = 'cancelada';
         await reserve.save();
 
         res.status(200).json({
@@ -256,7 +256,7 @@ router.post("/from-csv", async (req, res) => {
             reserve = await Reserve.create({
                 user,
                 room,
-                status: "accept",
+                status: 'aceita',
                 date: newDate
             })
 
@@ -355,7 +355,7 @@ router.post('/', verifyToken, async (req, res) => {
         const newReserve = new Reserve({
             user: userId._id,
             room: roomCod._id,
-            staus: req.body.status,
+            status: req.body.status,
             justification: req.body.justification,
             date: dateid
         });


### PR DESCRIPTION
Essa branch realiza a tradução do status da reserva para portugues e remove o status finalized. Para testar deve-se inserir reservas com os três status ("aceita","pendente" e "cancelada"), ao realizar o import do csv as reservas importadas devem ter o status "aceita" e ao realizar o cancelamento de uma reserva ela deve ter o status "cancelada".

Closes #72 