### PR TITLE
Permite que reservas sendo inseridas tenham conflito com reservas canceladas e pendentes

### DIFF
--- a/routes/reserve.js
+++ b/routes/reserve.js
@@ -316,6 +316,9 @@ router.post('/', verifyToken, async (req, res) => {
         conflictingDates = [];
 
         for(i = 0;i < roomReserves.length;i++){
+            if(roomReserves[i].status === 'cancelada' || roomReserves[i].status === 'pendente'){
+                continue;
+            }
             for(j = 0;j < roomReserves[i].date.length;j++){
                 for(h = 0;h < req.body.date.length;h++){
                     if(roomReserves[i].date[j].day_begin <= new Date(req.body.date[h].day_end) && roomReserves[i].date[j].day_end >= new Date(req.body.date[h].day_begin)){


### PR DESCRIPTION
Essa branch altera a rota de inserção de reservas para que a reserva a ser inserida possa ter conflito de horário com reservas canceladas e pendentes já registradas no banco de dados. Deve-se verificar que é possivel inserir reservas com conflito de data com reservas pendentes e canceladas mas não é possivel criar reservas com conflito com reservas aceitas.

Closes #77 