### PR TITLE
Fix da mensagem de login com credenciais erradas

### DIFF
--- a/frontend/src/pages/login.js
+++ b/frontend/src/pages/login.js
@@ -34,8 +34,8 @@ export default class Login extends Component {
 
             })
         }).then((response) => response.json()).then((json) => {
-            console.log(json.data.token)
             if (json.success) {
+                console.log(json.data.token)
                 localStorage.setItem("token", json.data.token);
                 axios.defaults.headers = {
                     "Authorization": localStorage.getItem("token")


### PR DESCRIPTION
Essa branch arruma a mensagem de login quando o usuário utiliza credenciais erradas, antes era feito um console.log do token, e caso o login não fosse bem succedido, esse campo não existia, desse modo ele caia no catch e dava a mensagem de não conseguir conectar no servidor.

Deve-se verificar que ao tentar fazer o login com credenciais erradas e ao tentar fazer o login com o backend desligado a mensagem correta apareça.

Closes #74 