### PR TITLE
Legenda calendário

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^16.4.2",
     "react-icons": "^3.0.5",
     "react-router-dom": "^4.3.1",
-    "react-scripts": "1.1.5",
+    "react-scripts": "^2.1.1",
     "reactstrap": "^6.4.0"
   },
   "scripts": {
@@ -27,5 +27,11 @@
   },
   "devDependencies": {
     "babel-cli": "^6.26.0"
-  }
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
 }

--- a/frontend/src/componentes/MainNavbar.js
+++ b/frontend/src/componentes/MainNavbar.js
@@ -52,13 +52,13 @@ class MainNavbar extends Component {
 
                         <Nav className="mr-auto">
                             <NavItem className="center">
-                                <NavLink href="/calendario" className="text-light"><b>Calendario</b></NavLink>
+                                <NavLink href="/calendario" className="text-light"><b>Calendário</b></NavLink>
                             </NavItem>
                         </Nav>
 
                         <Nav className="mr-auto">
                             <NavItem className="center">
-                                <NavLink href="" className="text-light"><b>Recursos e equipamentos</b></NavLink>
+                                <NavLink href="" className="text-light"><b>Recursos e Equipamentos</b></NavLink>
                             </NavItem>
                         </Nav>
 

--- a/frontend/src/pages/paginacalendario.js
+++ b/frontend/src/pages/paginacalendario.js
@@ -8,6 +8,7 @@ Modal, ModalHeader, ModalBody, ModalFooter
 import Calendario from '../componentes/calendario.js'
 import MainNavbar from '../componentes/MainNavbar.js'
 import $ from 'jquery';
+import './style.css';
 
 
 var startHour = {
@@ -181,20 +182,11 @@ class PaginaCalendario extends Component {
                             </Form>
                         </Col>
                         <Col>
-                            <Button color="primary" onClick={this.updateEvents}>OK</Button>
+                            <p className="legenda">Azul: Reservas confirmadas, não podem ser feitas reservas nesse horário.</p>
                         </Col>
-                        <Button color="info" onClick={() => {this.setState({modal: !this.state.modal})}}>Cores</Button>
-                        <Modal isOpen={this.state.modal} toggle={this.toggle} className={this.props.className}>
-                            <ModalHeader toggle={this.toggle}>Cor das reservas</ModalHeader>
-                            <ModalBody>
-                                Reservas na cor azul: Reservas confirmadas, não podem ser feitas reservas nesse horário.
-                                <br/>
-                                Reservas na cor laranja: Reservas que ainda dependem da decisão do administrador, podem ser feitas reservas no mesmo horário, mas o administrador terá que escolher uma.
-                            </ModalBody>
-                            <ModalFooter>
-                                <Button color="primary" onClick={() => {this.setState({modal: !this.state.modal})}}>Ok</Button>{' '}
-                            </ModalFooter>
-                        </Modal>
+                        <Col>
+                            <p className="legenda">Laranja: Reservas pendentes, podem ser feitas reservas no mesmo horário.</p>
+                        </Col>
                     </Row>
                     <Row>
                         <Col>

--- a/frontend/src/pages/paginacalendario.js
+++ b/frontend/src/pages/paginacalendario.js
@@ -182,10 +182,15 @@ class PaginaCalendario extends Component {
                             </Form>
                         </Col>
                         <Col>
-                            <p className="legenda">Azul: Reservas confirmadas, não podem ser feitas reservas nesse horário.</p>
+                            <Button color="primary" onClick={this.updateEvents}>OK</Button>
                         </Col>
+                            <div className="box-blue"></div>
                         <Col>
-                            <p className="legenda">Laranja: Reservas pendentes, podem ser feitas reservas no mesmo horário.</p>
+                            <p className="legenda">Reservas confirmadas, não podem ser feitas reservas nesse horário.</p>
+                        </Col>
+                            <div className="box-orange"></div>
+                        <Col>
+                            <p className="legenda">Reservas pendentes, podem ser feitas reservas nesse horário.</p>
                         </Col>
                     </Row>
                     <Row>

--- a/frontend/src/pages/style.css
+++ b/frontend/src/pages/style.css
@@ -1,0 +1,11 @@
+.legenda{
+	font-size: 14px;
+}
+
+.box-blue{
+	color: #3A87AD;
+}
+
+.box-orange{
+	color: #FB9700;
+}

--- a/frontend/src/pages/style.css
+++ b/frontend/src/pages/style.css
@@ -1,5 +1,8 @@
+@import url('https://fonts.googleapis.com/css?family=Ubuntu');
+
 .legenda{
 	font-size: 13px;
+	font-family: 'Ubuntu', sans-serif;
 }
 
 .box-blue{

--- a/frontend/src/pages/style.css
+++ b/frontend/src/pages/style.css
@@ -1,11 +1,19 @@
 .legenda{
-	font-size: 14px;
+	font-size: 13px;
 }
 
 .box-blue{
-	color: #3A87AD;
+	height:14px;
+	border: 14px solid;
+	border-color: #3A87AD;
+	border-radius: 4px;
+	margin-top: 10px;
 }
 
 .box-orange{
-	color: #FB9700;
+	height:14px;
+	border: 14px solid;
+	border-color: #FF9900;
+	border-radius: 4px;
+	margin-top: 10px;
 }


### PR DESCRIPTION
Foi removido o botão que mostrava um Modal com a legenda dos status do calendário, agora a legenda fica visível na tela do calendário com um quadrado da sua cor.

Coloquei o acento na palavra Calendário da mainNavBar também.

Closes #100 
Closes #105 