### PR TITLE
impedindo reserva de datas anteriores

### DIFF
--- a/frontend/src/pages/reserva.js
+++ b/frontend/src/pages/reserva.js
@@ -159,6 +159,10 @@ class Reserva extends Component {
             alert("Data de inicio maior que data de fim");
             return;
         }
+        if(this.state.frequencia[j] === 'Não se repete' && new Date(this.state.day_begin[j]) < new Date){
+          alert("Você não pode fazer uma reserva em um dia anterior ao de hoje")
+          return;
+        }
         if(this.state.frequencia[j] === 'Não se repete'){
           reserve.date.push({
             "day_begin": this.state.day_begin[j],


### PR DESCRIPTION
Essa branch impede que seja feita reservas com datas anteriores a data atual.
Para testar, basta abrir a pagina de reservas e efetuar uma reserva com o dia anterior ao de hoje.
A seguinte mensagem sera printada "Você não pode fazer uma reserva em um dia anterior ao de hoje"